### PR TITLE
Add support for UAPI and cPanel API 2 token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ username = 'USERNAME'
 password = 'PASSWORD'
 
 client = CPanelApi(hostname, username, password)
+
+# Alternatively, to authenticate using a UAPI or cPanel API 2 token, use:
+# client = CPanelApi(hostname, username, '<TOKEN>', auth_type = 'utoken')
+
 # {'warnings': None, 'errors': None, 'data': {'port': '1243'}, 'metadata': {}, 'status': 1, 'messages': None}
 r = client.uapi.SSH.get_port()
 print('SSH port:', r.data.port)

--- a/cpanel_api/__init__.py
+++ b/cpanel_api/__init__.py
@@ -91,7 +91,7 @@ class CPanelApi:
         password: str,
         port: int = 2083,
         *,
-        auth_type: Literal['hash', 'password', 'token'] = 'password',
+        auth_type: Literal['hash', 'password', 'token', 'utoken'] = 'password',
         session: Optional[requests.Session] = None,
         ssl: bool = True,
         timeout: float = 10.0,
@@ -120,6 +120,8 @@ class CPanelApi:
             auth = f'WHM {credentials}'
         elif self.auth_type == 'token':
             auth = f'whm {credentials}'
+        elif self.auth_type == 'utoken':
+            auth = f'cpanel {credentials}'
         else:
             raise ValueError(f'unknown auth type: {self.auth_type!r}')
         return auth


### PR DESCRIPTION
As per https://docs.cpanel.net/knowledge-base/security/how-to-use-cpanel-api-tokens/